### PR TITLE
Allocate enough memory to avoid a crash.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+.vs
+*.VC.opendb
+*.VC.db
+*.exe
+*.ilk
+*.pdb
+*.vcxproj.user
+*.lib
+src/compute_ma/
+src/compute_normals/
+src/simplify/
+thirdparty/x64/
+thirdparty/Debug/
+thirdparty/Release/
+
+

--- a/masbcpp.sln
+++ b/masbcpp.sln
@@ -1,0 +1,55 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "thirdparty", "thirdparty/thirdparty.vcxproj", "{513D08AE-3EEE-4241-B994-4A51AEA8FB2A}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "compute_ma", "src/compute_ma.vcxproj", "{513D08AE-3EEA-4241-B994-4A51AEA8FB2A}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "compute_normals", "src/compute_normals.vcxproj", "{513D08AE-3EEB-4241-B994-4A51AEA8FB2A}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "simplify", "src/simplify.vcxproj", "{513D08AE-3EEC-4241-B994-4A51AEA8FB2A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{513D08AE-3EEE-4241-B994-4A51AEA8FB2A}.Debug|x64.ActiveCfg = Debug|x64
+		{513D08AE-3EEE-4241-B994-4A51AEA8FB2A}.Debug|x64.Build.0 = Debug|x64
+		{513D08AE-3EEE-4241-B994-4A51AEA8FB2A}.Debug|x86.ActiveCfg = Debug|Win32
+		{513D08AE-3EEE-4241-B994-4A51AEA8FB2A}.Debug|x86.Build.0 = Debug|Win32
+		{513D08AE-3EEE-4241-B994-4A51AEA8FB2A}.Release|x64.ActiveCfg = Release|x64
+		{513D08AE-3EEE-4241-B994-4A51AEA8FB2A}.Release|x64.Build.0 = Release|x64
+		{513D08AE-3EEE-4241-B994-4A51AEA8FB2A}.Release|x86.ActiveCfg = Release|Win32
+		{513D08AE-3EEE-4241-B994-4A51AEA8FB2A}.Release|x86.Build.0 = Release|Win32
+		{513D08AE-3EEA-4241-B994-4A51AEA8FB2A}.Debug|x64.ActiveCfg = Debug|x64
+		{513D08AE-3EEA-4241-B994-4A51AEA8FB2A}.Debug|x64.Build.0 = Debug|x64
+		{513D08AE-3EEA-4241-B994-4A51AEA8FB2A}.Debug|x86.ActiveCfg = Debug|Win32
+		{513D08AE-3EEA-4241-B994-4A51AEA8FB2A}.Debug|x86.Build.0 = Debug|Win32
+		{513D08AE-3EEA-4241-B994-4A51AEA8FB2A}.Release|x64.ActiveCfg = Release|x64
+		{513D08AE-3EEA-4241-B994-4A51AEA8FB2A}.Release|x64.Build.0 = Release|x64
+		{513D08AE-3EEA-4241-B994-4A51AEA8FB2A}.Release|x86.ActiveCfg = Release|Win32
+		{513D08AE-3EEA-4241-B994-4A51AEA8FB2A}.Release|x86.Build.0 = Release|Win32
+		{513D08AE-3EEB-4241-B994-4A51AEA8FB2A}.Debug|x64.ActiveCfg = Debug|x64
+		{513D08AE-3EEB-4241-B994-4A51AEA8FB2A}.Debug|x64.Build.0 = Debug|x64
+		{513D08AE-3EEB-4241-B994-4A51AEA8FB2A}.Debug|x86.ActiveCfg = Debug|Win32
+		{513D08AE-3EEB-4241-B994-4A51AEA8FB2A}.Debug|x86.Build.0 = Debug|Win32
+		{513D08AE-3EEB-4241-B994-4A51AEA8FB2A}.Release|x64.ActiveCfg = Release|x64
+		{513D08AE-3EEB-4241-B994-4A51AEA8FB2A}.Release|x64.Build.0 = Release|x64
+		{513D08AE-3EEB-4241-B994-4A51AEA8FB2A}.Release|x86.ActiveCfg = Release|Win32
+		{513D08AE-3EEB-4241-B994-4A51AEA8FB2A}.Release|x86.Build.0 = Release|Win32
+		{513D08AE-3EEC-4241-B994-4A51AEA8FB2A}.Debug|x64.ActiveCfg = Debug|x64
+		{513D08AE-3EEC-4241-B994-4A51AEA8FB2A}.Debug|x64.Build.0 = Debug|x64
+		{513D08AE-3EEC-4241-B994-4A51AEA8FB2A}.Debug|x86.ActiveCfg = Debug|Win32
+		{513D08AE-3EEC-4241-B994-4A51AEA8FB2A}.Debug|x86.Build.0 = Debug|Win32
+		{513D08AE-3EEC-4241-B994-4A51AEA8FB2A}.Release|x64.ActiveCfg = Release|x64
+		{513D08AE-3EEC-4241-B994-4A51AEA8FB2A}.Release|x64.Build.0 = Release|x64
+		{513D08AE-3EEC-4241-B994-4A51AEA8FB2A}.Release|x86.ActiveCfg = Release|Win32
+		{513D08AE-3EEC-4241-B994-4A51AEA8FB2A}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/compute_ma.cpp
+++ b/src/compute_ma.cpp
@@ -28,6 +28,11 @@ SOFTWARE.
 #include <string>
 #include <limits>
 
+// Required on Windows, if you use the boolean operators "and" and "or" instead of "&&" and "||"
+#ifndef and
+#include <iso646.h>
+#endif
+
 // OpenMP
 #ifdef WITH_OPENMP
     #include <omp.h>
@@ -184,7 +189,7 @@ void sb_points(PointList &points, VectorList &normals, kdtree2::KDTree* kd_tree,
     Vector n;
 
     #pragma omp parallel for private(p, n)
-    for( unsigned int i=0; i<points.size(); i++ )
+    for( int i=0; i<points.size(); i++ )
     {
         p = points[i];
         if( inner )
@@ -227,10 +232,13 @@ int main(int argc, char **argv)
         std::string output_path = inputArg.getValue();
         if(outputArg.isSet())
             output_path = outputArg.getValue();
+        std::replace(output_path.begin(), output_path.end(), '\\', '/');
 
         // check for proper in-output arguments and set in and output filepath strings
         std::string input_coords_path = inputArg.getValue()+"/coords.npy";
+        std::replace(input_coords_path.begin(), input_coords_path.end(), '\\', '/');
         std::string input_normals_path = inputArg.getValue()+"/normals.npy";
+        std::replace(input_normals_path.begin(), input_normals_path.end(), '\\', '/');
         std::string output_path_ma_in = output_path+"/ma_coords_in.npy";
         std::string output_path_ma_out = output_path+"/ma_coords_out.npy";
         std::string output_path_ma_q_in = output_path+"/ma_qidx_in.npy";
@@ -259,13 +267,13 @@ int main(int argc, char **argv)
 	    unsigned int num_points = coords_npy.shape[0];
 	    unsigned int dim = coords_npy.shape[1];
 	    PointList coords(num_points);
-	    for ( int i=0; i<num_points; i++) coords[i] = Point(&coords_carray[i*3]);
+	    for ( unsigned int i=0; i<num_points; i++) coords[i] = Point(&coords_carray[i*3]);
 	    coords_npy.destruct();
 
 	    cnpy::NpyArray normals_npy = cnpy::npy_load( input_normals_path.c_str() );
 	    float* normals_carray = reinterpret_cast<float*>(normals_npy.data);
 	    VectorList normals(normals_npy.shape[0]);
-	    for ( int i=0; i<num_points; i++) normals[i] = Vector(&normals_carray[i*3]);
+	    for ( unsigned int i=0; i<num_points; i++) normals[i] = Vector(&normals_carray[i*3]);
 	    normals_npy.destruct();
 	    
         #ifndef __MINGW32__

--- a/src/compute_ma.vcxproj
+++ b/src/compute_ma.vcxproj
@@ -1,0 +1,183 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{513D08AE-3EEA-4241-B994-4A51AEA8FB2A}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>compute_ma</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <ProjectName>compute_ma</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(ProjectDir)</OutDir>
+    <IntDir>$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(ProjectDir)</OutDir>
+    <IntDir>$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(ProjectDir)</OutDir>
+    <IntDir>$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(ProjectDir)</OutDir>
+    <IntDir>$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WITH_OPENMP;WIN32;_USE_MATH_DEFINES;NOMINMAX;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\thirdparty\;..\thirdparty\vrui\;..\..\zlib\include\</AdditionalIncludeDirectories>
+      <OpenMPSupport>true</OpenMPSupport>
+      <DisableSpecificWarnings>4018;4267;4996;4244;4396</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>winmm.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WITH_OPENMP;WIN32;_USE_MATH_DEFINES;NOMINMAX;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\thirdparty\;..\thirdparty\vrui\;..\..\zlib\include\</AdditionalIncludeDirectories>
+      <OpenMPSupport>true</OpenMPSupport>
+      <DisableSpecificWarnings>4018;4267;4996;4244;4396</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>winmm.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WITH_OPENMP;WIN32;_USE_MATH_DEFINES;NOMINMAX;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\thirdparty\;..\thirdparty\vrui\;..\..\zlib\include\</AdditionalIncludeDirectories>
+      <OpenMPSupport>true</OpenMPSupport>
+      <DisableSpecificWarnings>4018;4267;4996;4244;4396</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>winmm.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WITH_OPENMP;WIN32;_USE_MATH_DEFINES;NOMINMAX;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\thirdparty\;..\thirdparty\vrui\;..\..\zlib\include\</AdditionalIncludeDirectories>
+      <OpenMPSupport>true</OpenMPSupport>
+      <DisableSpecificWarnings>4018;4267;4996;4244;4396</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>winmm.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include=".\types.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include=".\compute_ma.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\thirdparty\thirdparty.vcxproj">
+      <Project>{513d08ae-3eee-4241-b994-4a51aea8fb2a}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/compute_ma.vcxproj.filters
+++ b/src/compute_ma.vcxproj.filters
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include=".\types.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include=".\compute_ma.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/src/compute_normals.cpp
+++ b/src/compute_normals.cpp
@@ -69,7 +69,7 @@ VectorList estimate_normals(PointList &points, kdtree2::KDTree* kd_tree, int k)
     VectorList normals(points.size());
 
     #pragma omp parallel for
-    for( unsigned int i=0; i<points.size(); i++ )
+    for( int i=0; i<points.size(); i++ )
         normals[i] = estimate_normal( points[i], kd_tree, k );
 
     return normals;
@@ -98,8 +98,12 @@ int main(int argc, char **argv)
         std::string output_path = inputArg.getValue();
         if(outputArg.isSet())
             output_path = outputArg.getValue();
+        std::replace(output_path.begin(), output_path.end(), '\\', '/');
+
 
         std::string input_coords_path = inputArg.getValue()+"/coords.npy";
+        std::replace(input_coords_path.begin(), input_coords_path.end(), '\\', '/');
+
         output_path += "/normals.npy";
         // check for proper in-output arguments
         {

--- a/src/compute_normals.vcxproj
+++ b/src/compute_normals.vcxproj
@@ -1,0 +1,183 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{513D08AE-3EEB-4241-B994-4A51AEA8FB2A}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>compute_normals</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <ProjectName>compute_normals</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(ProjectDir)</OutDir>
+    <IntDir>$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(ProjectDir)</OutDir>
+    <IntDir>$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(ProjectDir)</OutDir>
+    <IntDir>$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(ProjectDir)</OutDir>
+    <IntDir>$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WITH_OPENMP;WIN32;_USE_MATH_DEFINES;NOMINMAX;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\thirdparty\;..\thirdparty\vrui\;..\..\zlib\include\</AdditionalIncludeDirectories>
+      <OpenMPSupport>true</OpenMPSupport>
+      <DisableSpecificWarnings>4018;4267;4996;4244;4396</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>winmm.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WITH_OPENMP;WIN32;_USE_MATH_DEFINES;NOMINMAX;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\thirdparty\;..\thirdparty\vrui\;..\..\zlib\include\</AdditionalIncludeDirectories>
+      <OpenMPSupport>true</OpenMPSupport>
+      <DisableSpecificWarnings>4018;4267;4996;4244;4396</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>winmm.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WITH_OPENMP;WIN32;_USE_MATH_DEFINES;NOMINMAX;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\thirdparty\;..\thirdparty\vrui\;..\..\zlib\include\</AdditionalIncludeDirectories>
+      <OpenMPSupport>true</OpenMPSupport>
+      <DisableSpecificWarnings>4018;4267;4996;4244;4396</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>winmm.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WITH_OPENMP;WIN32;_USE_MATH_DEFINES;NOMINMAX;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\thirdparty\;..\thirdparty\vrui\;..\..\zlib\include\</AdditionalIncludeDirectories>
+      <OpenMPSupport>true</OpenMPSupport>
+      <DisableSpecificWarnings>4018;4267;4996;4244;4396</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>winmm.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include=".\types.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="compute_normals.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\thirdparty\thirdparty.vcxproj">
+      <Project>{513d08ae-3eee-4241-b994-4a51aea8fb2a}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/compute_normals.vcxproj.filters
+++ b/src/compute_normals.vcxproj.filters
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include=".\types.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="compute_normals.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/src/simplify.cpp
+++ b/src/simplify.cpp
@@ -349,7 +349,7 @@ int main(int argc, char **argv)
         // madata.normals = &normals;
         madata.ma_coords = &ma_coords;
 
-        madata.mask = new bool[madata.m];
+        madata.mask = new bool[2*madata.m];
         madata.lfs = new float[madata.m];
 
 	    {

--- a/src/simplify.vcxproj
+++ b/src/simplify.vcxproj
@@ -1,0 +1,183 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{513D08AE-3EEC-4241-B994-4A51AEA8FB2A}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>simplify</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <ProjectName>simplify</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(ProjectDir)</OutDir>
+    <IntDir>$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(ProjectDir)</OutDir>
+    <IntDir>$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(ProjectDir)</OutDir>
+    <IntDir>$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(ProjectDir)</OutDir>
+    <IntDir>$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WITH_OPENMP;WIN32;_USE_MATH_DEFINES;NOMINMAX;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\thirdparty\;..\thirdparty\vrui\;..\..\zlib\include\</AdditionalIncludeDirectories>
+      <OpenMPSupport>true</OpenMPSupport>
+      <DisableSpecificWarnings>4018;4267;4996;4244;4396</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>winmm.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WITH_OPENMP;WIN32;_USE_MATH_DEFINES;NOMINMAX;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\thirdparty\;..\thirdparty\vrui\;..\..\zlib\include\</AdditionalIncludeDirectories>
+      <OpenMPSupport>true</OpenMPSupport>
+      <DisableSpecificWarnings>4018;4267;4996;4244;4396</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>winmm.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WITH_OPENMP;WIN32;_USE_MATH_DEFINES;NOMINMAX;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\thirdparty\;..\thirdparty\vrui\;..\..\zlib\include\</AdditionalIncludeDirectories>
+      <OpenMPSupport>true</OpenMPSupport>
+      <DisableSpecificWarnings>4018;4267;4996;4244;4396</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>winmm.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WITH_OPENMP;WIN32;_USE_MATH_DEFINES;NOMINMAX;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\thirdparty\;..\thirdparty\vrui\;..\..\zlib\include\</AdditionalIncludeDirectories>
+      <OpenMPSupport>true</OpenMPSupport>
+      <DisableSpecificWarnings>4018;4267;4996;4244;4396</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>winmm.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include=".\types.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include=".\simplify.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\thirdparty\thirdparty.vcxproj">
+      <Project>{513d08ae-3eee-4241-b994-4a51aea8fb2a}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/simplify.vcxproj.filters
+++ b/src/simplify.vcxproj.filters
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include=".\types.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include=".\simplify.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/thirdparty/kdtree2/kdtree2.cpp
+++ b/thirdparty/kdtree2/kdtree2.cpp
@@ -99,10 +99,7 @@ namespace kdtree2 {
             
             // permute the data for it.
             for (int i=0; i<N; i++) {
-                for (int j=0; j<dim; j++) {
-                    rearranged_data[i][j] = the_data[ind[i]][j];
-                    // wouldn't F90 be nice here?
-                }
+                rearranged_data.push_back(the_data[ind[i]]);
             }
             data = &rearranged_data;
         } else {

--- a/thirdparty/kdtree2/kdtree2.hpp
+++ b/thirdparty/kdtree2/kdtree2.hpp
@@ -207,7 +207,7 @@ namespace kdtree2 {
         // return true if the bounding box for this node is within the
         // search range given by the searchvector and maximum ballsize in 'sr'. 
         
-        void check_query_in_bound(SearchRecord& sr); // debugging only
+        void check_query_in_bound(SearchRecord& sr) {}; // debugging only
         
         // for processing final buckets. 
         void process_terminal_node(SearchRecord& sr);

--- a/thirdparty/thirdparty.vcxproj
+++ b/thirdparty/thirdparty.vcxproj
@@ -1,0 +1,230 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{513D08AE-3EEE-4241-B994-4A51AEA8FB2A}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>thirdparty</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <ProjectName>thirdparty</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(ProjectDir)</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(ProjectDir)</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(ProjectDir)</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(ProjectDir)</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WITH_OPENMP;WIN32;_USE_MATH_DEFINES;NOMINMAX;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\;.\vrui\;..\..\zlib\include\</AdditionalIncludeDirectories>
+      <OpenMPSupport>true</OpenMPSupport>
+      <DisableSpecificWarnings>4018;4267;4996;4244;4396</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>winmm.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WITH_OPENMP;WIN32;_USE_MATH_DEFINES;NOMINMAX;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\;.\vrui\;..\..\zlib\include\</AdditionalIncludeDirectories>
+      <OpenMPSupport>true</OpenMPSupport>
+      <DisableSpecificWarnings>4018;4267;4996;4244;4396</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>winmm.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WITH_OPENMP;WIN32;_USE_MATH_DEFINES;NOMINMAX;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\;.\vrui\;..\..\zlib\include\</AdditionalIncludeDirectories>
+      <OpenMPSupport>true</OpenMPSupport>
+      <DisableSpecificWarnings>4018;4267;4996;4244;4396</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>winmm.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WITH_OPENMP;WIN32;_USE_MATH_DEFINES;NOMINMAX;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\;.\vrui\;..\..\zlib\include\</AdditionalIncludeDirectories>
+      <OpenMPSupport>true</OpenMPSupport>
+      <DisableSpecificWarnings>4018;4267;4996;4244;4396</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>winmm.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include=".\cnpy\cnpy.h" />
+    <ClInclude Include=".\kdtree2\kdtree2.hpp" />
+    <ClInclude Include=".\tclap\Arg.h" />
+    <ClInclude Include=".\tclap\ArgException.h" />
+    <ClInclude Include=".\tclap\ArgTraits.h" />
+    <ClInclude Include=".\tclap\CmdLine.h" />
+    <ClInclude Include=".\tclap\CmdLineInterface.h" />
+    <ClInclude Include=".\tclap\CmdLineOutput.h" />
+    <ClInclude Include=".\tclap\Constraint.h" />
+    <ClInclude Include=".\tclap\DocBookOutput.h" />
+    <ClInclude Include=".\tclap\HelpVisitor.h" />
+    <ClInclude Include=".\tclap\IgnoreRestVisitor.h" />
+    <ClInclude Include=".\tclap\MultiArg.h" />
+    <ClInclude Include=".\tclap\MultiSwitchArg.h" />
+    <ClInclude Include=".\tclap\OptionalUnlabeledTracker.h" />
+    <ClInclude Include=".\tclap\StandardTraits.h" />
+    <ClInclude Include=".\tclap\StdOutput.h" />
+    <ClInclude Include=".\tclap\SwitchArg.h" />
+    <ClInclude Include=".\tclap\UnlabeledMultiArg.h" />
+    <ClInclude Include=".\tclap\UnlabeledValueArg.h" />
+    <ClInclude Include=".\tclap\ValueArg.h" />
+    <ClInclude Include=".\tclap\ValuesConstraint.h" />
+    <ClInclude Include=".\tclap\VersionVisitor.h" />
+    <ClInclude Include=".\tclap\Visitor.h" />
+    <ClInclude Include=".\tclap\XorHandler.h" />
+    <ClInclude Include=".\tclap\ZshCompletionOutput.h" />
+    <ClInclude Include=".\vrui\Geometry\Box.h" />
+    <ClInclude Include=".\vrui\Geometry\ComponentArray.h" />
+    <ClInclude Include=".\vrui\Geometry\HitResult.h" />
+    <ClInclude Include=".\vrui\Geometry\Matrix.h" />
+    <ClInclude Include=".\vrui\Geometry\MatrixHelperFunctions.h" />
+    <ClInclude Include=".\vrui\Geometry\PCACalculator.h" />
+    <ClInclude Include=".\vrui\Geometry\Point.h" />
+    <ClInclude Include=".\vrui\Geometry\Ray.h" />
+    <ClInclude Include=".\vrui\Geometry\SolidHitResult.h" />
+    <ClInclude Include=".\vrui\Geometry\Vector.h" />
+    <ClInclude Include=".\vrui\Math\Constants.h" />
+    <ClInclude Include=".\vrui\Math\Math.h" />
+    <ClInclude Include=".\vrui\Misc\Timer.h" />
+    <ClInclude Include=".\vrui\Misc\Utility.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include=".\cnpy\cnpy.cpp" />
+    <ClCompile Include=".\kdtree2\kdtree2.cpp" />
+    <ClCompile Include=".\vrui\Geometry\Box.cpp" />
+    <ClCompile Include=".\vrui\Geometry\ComponentArray.cpp" />
+    <ClCompile Include=".\vrui\Geometry\Matrix.cpp" />
+    <ClCompile Include=".\vrui\Geometry\PCACalculator.cpp" />
+    <ClCompile Include=".\vrui\Geometry\Point.cpp" />
+    <ClCompile Include=".\vrui\Geometry\Vector.cpp" />
+    <ClCompile Include=".\vrui\Math\Constants.cpp" />
+    <ClCompile Include=".\vrui\Misc\Timer.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include=".\tclap\COPYING" />
+    <None Include=".\vrui\Geometry\Box.icpp" />
+    <None Include=".\vrui\Geometry\ComponentArray.icpp" />
+    <None Include=".\vrui\Geometry\Matrix.icpp" />
+    <None Include=".\vrui\Geometry\Point.icpp" />
+    <None Include=".\vrui\Geometry\Vector.icpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/thirdparty/thirdparty.vcxproj.filters
+++ b/thirdparty/thirdparty.vcxproj.filters
@@ -1,0 +1,203 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\kdtree">
+      <UniqueIdentifier>{acca108a-2c36-41ee-984b-422dd314ed4f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\vrui">
+      <UniqueIdentifier>{cc0fb598-e5ab-4bc9-9045-aeab2ce708a8}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\cnpy">
+      <UniqueIdentifier>{e211ef40-8e4b-456d-aa38-7e98ea59815f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\tclap">
+      <UniqueIdentifier>{f32b3c59-542f-43c6-82e3-bfee088e7f43}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include=".\kdtree2\kdtree2.hpp">
+      <Filter>Source Files\kdtree</Filter>
+    </ClInclude>
+    <ClInclude Include=".\vrui\Misc\Timer.h">
+      <Filter>Source Files\vrui</Filter>
+    </ClInclude>
+    <ClInclude Include=".\vrui\Misc\Utility.h">
+      <Filter>Source Files\vrui</Filter>
+    </ClInclude>
+    <ClInclude Include=".\vrui\Math\Constants.h">
+      <Filter>Source Files\vrui</Filter>
+    </ClInclude>
+    <ClInclude Include=".\vrui\Math\Math.h">
+      <Filter>Source Files\vrui</Filter>
+    </ClInclude>
+    <ClInclude Include=".\vrui\Geometry\Box.h">
+      <Filter>Source Files\vrui</Filter>
+    </ClInclude>
+    <ClInclude Include=".\vrui\Geometry\ComponentArray.h">
+      <Filter>Source Files\vrui</Filter>
+    </ClInclude>
+    <ClInclude Include=".\vrui\Geometry\HitResult.h">
+      <Filter>Source Files\vrui</Filter>
+    </ClInclude>
+    <ClInclude Include=".\vrui\Geometry\Matrix.h">
+      <Filter>Source Files\vrui</Filter>
+    </ClInclude>
+    <ClInclude Include=".\vrui\Geometry\MatrixHelperFunctions.h">
+      <Filter>Source Files\vrui</Filter>
+    </ClInclude>
+    <ClInclude Include=".\vrui\Geometry\PCACalculator.h">
+      <Filter>Source Files\vrui</Filter>
+    </ClInclude>
+    <ClInclude Include=".\vrui\Geometry\Point.h">
+      <Filter>Source Files\vrui</Filter>
+    </ClInclude>
+    <ClInclude Include=".\vrui\Geometry\Ray.h">
+      <Filter>Source Files\vrui</Filter>
+    </ClInclude>
+    <ClInclude Include=".\vrui\Geometry\SolidHitResult.h">
+      <Filter>Source Files\vrui</Filter>
+    </ClInclude>
+    <ClInclude Include=".\vrui\Geometry\Vector.h">
+      <Filter>Source Files\vrui</Filter>
+    </ClInclude>
+    <ClInclude Include=".\cnpy\cnpy.h">
+      <Filter>Source Files\cnpy</Filter>
+    </ClInclude>
+    <ClInclude Include=".\tclap\Arg.h">
+      <Filter>Source Files\tclap</Filter>
+    </ClInclude>
+    <ClInclude Include=".\tclap\ArgException.h">
+      <Filter>Source Files\tclap</Filter>
+    </ClInclude>
+    <ClInclude Include=".\tclap\ArgTraits.h">
+      <Filter>Source Files\tclap</Filter>
+    </ClInclude>
+    <ClInclude Include=".\tclap\CmdLine.h">
+      <Filter>Source Files\tclap</Filter>
+    </ClInclude>
+    <ClInclude Include=".\tclap\CmdLineInterface.h">
+      <Filter>Source Files\tclap</Filter>
+    </ClInclude>
+    <ClInclude Include=".\tclap\CmdLineOutput.h">
+      <Filter>Source Files\tclap</Filter>
+    </ClInclude>
+    <ClInclude Include=".\tclap\Constraint.h">
+      <Filter>Source Files\tclap</Filter>
+    </ClInclude>
+    <ClInclude Include=".\tclap\DocBookOutput.h">
+      <Filter>Source Files\tclap</Filter>
+    </ClInclude>
+    <ClInclude Include=".\tclap\HelpVisitor.h">
+      <Filter>Source Files\tclap</Filter>
+    </ClInclude>
+    <ClInclude Include=".\tclap\IgnoreRestVisitor.h">
+      <Filter>Source Files\tclap</Filter>
+    </ClInclude>
+    <ClInclude Include=".\tclap\MultiArg.h">
+      <Filter>Source Files\tclap</Filter>
+    </ClInclude>
+    <ClInclude Include=".\tclap\MultiSwitchArg.h">
+      <Filter>Source Files\tclap</Filter>
+    </ClInclude>
+    <ClInclude Include=".\tclap\OptionalUnlabeledTracker.h">
+      <Filter>Source Files\tclap</Filter>
+    </ClInclude>
+    <ClInclude Include=".\tclap\StandardTraits.h">
+      <Filter>Source Files\tclap</Filter>
+    </ClInclude>
+    <ClInclude Include=".\tclap\StdOutput.h">
+      <Filter>Source Files\tclap</Filter>
+    </ClInclude>
+    <ClInclude Include=".\tclap\SwitchArg.h">
+      <Filter>Source Files\tclap</Filter>
+    </ClInclude>
+    <ClInclude Include=".\tclap\UnlabeledMultiArg.h">
+      <Filter>Source Files\tclap</Filter>
+    </ClInclude>
+    <ClInclude Include=".\tclap\UnlabeledValueArg.h">
+      <Filter>Source Files\tclap</Filter>
+    </ClInclude>
+    <ClInclude Include=".\tclap\ValueArg.h">
+      <Filter>Source Files\tclap</Filter>
+    </ClInclude>
+    <ClInclude Include=".\tclap\ValuesConstraint.h">
+      <Filter>Source Files\tclap</Filter>
+    </ClInclude>
+    <ClInclude Include=".\tclap\VersionVisitor.h">
+      <Filter>Source Files\tclap</Filter>
+    </ClInclude>
+    <ClInclude Include=".\tclap\Visitor.h">
+      <Filter>Source Files\tclap</Filter>
+    </ClInclude>
+    <ClInclude Include=".\tclap\XorHandler.h">
+      <Filter>Source Files\tclap</Filter>
+    </ClInclude>
+    <ClInclude Include=".\tclap\ZshCompletionOutput.h">
+      <Filter>Source Files\tclap</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include=".\kdtree2\kdtree2.cpp">
+      <Filter>Source Files\kdtree</Filter>
+    </ClCompile>
+    <ClCompile Include=".\vrui\Misc\Timer.cpp">
+      <Filter>Source Files\vrui</Filter>
+    </ClCompile>
+    <ClCompile Include=".\vrui\Math\Constants.cpp">
+      <Filter>Source Files\vrui</Filter>
+    </ClCompile>
+    <ClCompile Include=".\vrui\Geometry\Box.cpp">
+      <Filter>Source Files\vrui</Filter>
+    </ClCompile>
+    <ClCompile Include=".\vrui\Geometry\ComponentArray.cpp">
+      <Filter>Source Files\vrui</Filter>
+    </ClCompile>
+    <ClCompile Include=".\vrui\Geometry\Matrix.cpp">
+      <Filter>Source Files\vrui</Filter>
+    </ClCompile>
+    <ClCompile Include=".\vrui\Geometry\PCACalculator.cpp">
+      <Filter>Source Files\vrui</Filter>
+    </ClCompile>
+    <ClCompile Include=".\vrui\Geometry\Point.cpp">
+      <Filter>Source Files\vrui</Filter>
+    </ClCompile>
+    <ClCompile Include=".\vrui\Geometry\Vector.cpp">
+      <Filter>Source Files\vrui</Filter>
+    </ClCompile>
+    <ClCompile Include=".\cnpy\cnpy.cpp">
+      <Filter>Source Files\cnpy</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include=".\vrui\Geometry\Box.icpp">
+      <Filter>Source Files\vrui</Filter>
+    </None>
+    <None Include=".\vrui\Geometry\ComponentArray.icpp">
+      <Filter>Source Files\vrui</Filter>
+    </None>
+    <None Include=".\vrui\Geometry\Matrix.icpp">
+      <Filter>Source Files\vrui</Filter>
+    </None>
+    <None Include=".\vrui\Geometry\Point.icpp">
+      <Filter>Source Files\vrui</Filter>
+    </None>
+    <None Include=".\vrui\Geometry\Vector.icpp">
+      <Filter>Source Files\vrui</Filter>
+    </None>
+    <None Include=".\tclap\COPYING">
+      <Filter>Source Files\tclap</Filter>
+    </None>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
It appears to me that the array "madata.mask" is not allocated with the correct size.

Without this fix, the loop below, crashes, in simplify.cpp: (array out of bounds)
``` cpp
        for( int i=0; i<N; i++ ){
            madata.mask[i] = false;
            if( madata.ma_qidx[i] != -1 ){
                kd_tree.n_nearest((*madata.ma_coords)[i], k, result);
                
                float bisec_angle = acos((*madata.ma_bisec)[result[1].idx] * (*madata.ma_bisec)[i]);
                if( bisec_angle < bisec_threshold )
                    madata.mask[i] = true;
            }
        }
```
