### PR TITLE
Added a method to do simplify in one step.

### DIFF
--- a/src/simplify.cpp
+++ b/src/simplify.cpp
@@ -96,7 +96,7 @@ int main(int argc, char **argv)
                 throw TCLAP::ArgParseException("invalid filepath", output_path);
         }
 
-        ma_data madata = {};
+        lfs_data madata = {};
 	    
 	    cnpy::NpyArray coords_npy = cnpy::npy_load( input_coords_path.c_str() );
 	    float* coords_carray = reinterpret_cast<float*>(coords_npy.data);

--- a/src/simplify_processing.h
+++ b/src/simplify_processing.h
@@ -24,6 +24,8 @@ SOFTWARE.
 #define SIMPLIFY_PROCESSING_
 
 #include "types.h"
+#include "compute_normals_processing.h"
+#include "compute_ma_processing.h"
 
 struct simplify_parameters {
    double epsilon;
@@ -34,6 +36,27 @@ struct simplify_parameters {
    bool only_inner;
 };
 
-void simplify_lfs(simplify_parameters &input_parameters, ma_data& madata);
+struct lfs_data {
+   int m;
+   Box bbox;
+
+   PointList *coords; // don't own this memory
+   PointList *ma_coords; // don't own this memory
+   int *ma_qidx;
+
+   float *lfs;
+   bool *mask;
+};
+
+
+// This version of simplify takes in an already calculated ma, etc.
+void simplify_lfs(simplify_parameters &input_parameters, lfs_data& madata);
+
+// This version of simplify takes in only the coords of the original point cloud.
+void simplify(normals_parameters &normals_params, 
+              ma_parameters &ma_params, 
+              simplify_parameters &simplify_params,
+              PointList &coords,
+              bool *mask); // mask *must* be allocated ahead of time to be an array of size "2*coords.size()".
 
 #endif

--- a/src/types.h
+++ b/src/types.h
@@ -23,6 +23,8 @@ SOFTWARE.
 #ifndef MASBCPP_TYPES_
 #define MASBCPP_TYPES_
 
+#include <vector>
+
 #include <vrui/Geometry/Vector.h>
 #include <vrui/Geometry/Point.h>
 #include <vrui/Geometry/Box.h>
@@ -35,19 +37,5 @@ typedef std::vector<Vector> VectorList; // Type for 3D vectors
 typedef Geometry::Box<Scalar,3> Box; // Type for 3D Box
 
 typedef std::vector<int> intList; // Type for ints
-
-struct ma_data {
-	int m;
-	Box bbox;
-
-	PointList *coords; // don't own this memory
-	//VectorList *normals;
-	PointList *ma_coords; // don't own this memory
-	int *ma_qidx;
-	//VectorList *ma_bisec;
-
-	float *lfs;
-	bool *mask;
-};
 
 #endif


### PR DESCRIPTION
Adding a single step method for simplify has had the effect of highlighting some areas where optimization is pretty obvious.  I'll list a few here:
  1) ma_coords and ma_qidx values (for inner and outer) are stored slightly differently in the methods "compute_masb_points" and "simplify_lfs".  This means there is some copying of values between these calls.  If they both used the same structure this copying would not be needed.
  2) "mask" is allocated as 2\*coords.size() before it is passed into the "simplify_lfs" method.  I'm not sure, but I think all of these mask values are computed.  (Is the first half simplifying based on the inner ma, and the second half simplifying based on the outer ma?)  It appears that the final output of simplify only uses the first half of the "mask" results.  Maybe you could clarify what both halves of the "mask" values mean, or maybe reduce the work to only the first half if that is all that is useful?
  3) The kd-trees are not shared between the methods "compute_normals", "compute_masb_points", and "simplify_lfs".  Maybe you could modify it so these methods pass *out* any useful kd-trees they create, and take *in* any kd-trees they may require.  Maybe the *in* kd-trees could be optional, so it still could compute them if the method is called all by itself.
