### PR TITLE
Skip ball shrinking for invalid points or normals

### DIFF
--- a/src/compute_ma_processing.cpp
+++ b/src/compute_ma_processing.cpp
@@ -69,6 +69,10 @@ ma_result sb_point(const ma_parameters &input_parameters, const Vector3 &p, cons
    int qidx = -1, qidx_next;
    Point c; c.getVector3fMap() = p - n * r;
 
+   // We can't continue if we have bad input, we won't be able to perform nearest neighbour searches
+   if (!n.allFinite() || !p.allFinite())
+      return{ c, qidx };
+
    // Results from our search
    std::vector<int> k_indices(2);
    std::vector<Scalar> k_distances(2);


### PR DESCRIPTION
Due to some 32 bit precision issues in the calculation of covariance matrices, it is possible for PCL's `NormalEstimationOMP` class to produce NaN results. These NaN normals can crash the `sb_point` function because the nearest neighbour search cannot give reasonable results for NaN inputs.