### PR TITLE
add required PCL version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ make
 Building on windows should be possible with Visual Studio.
 
 ### External dependencies
-[PCL](https://github.com/PointCloudLibrary/pcl) is currently the only dependency that is not included in this distribution (but PCL has many dependencies of its own).
+[PCL](https://github.com/PointCloudLibrary/pcl) is currently the only dependency that is not included in this distribution (but PCL has many dependencies of its own). `masbcpp` requires PCL 1.8
 
 ###Build with OpenMP support (multithreading)
 The build system should autodetect whether your compiler supports OpenMP and build masbpp with multithreading support accordingly. To enable multithreading on Mac OS X (tested with version 10.10), do


### PR DESCRIPTION
Currently PCL 1.7.2 is included in Ubuntu 16.04, and there are no prebuilt Linux binaries available for 1.8. Knowing the required version saves some googlin'